### PR TITLE
Add missing import statements in generated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The following parameters are configurable for the API Client:
 The API client can be initialized as follows:
 
 ```python
+from advancedbilling.advanced_billing_client import AdvancedBillingClient
+from advancedbilling.configuration import Environment
+from advancedbilling.http.auth.basic_auth import BasicAuthCredentials
+
 client = AdvancedBillingClient(
     basic_auth_credentials=BasicAuthCredentials(
         username='BasicAuthUserName',

--- a/doc/auth/basic-authentication.md
+++ b/doc/auth/basic-authentication.md
@@ -23,6 +23,9 @@ Documentation for accessing and setting credentials for BasicAuth.
 You must provide credentials in the client as shown in the following code snippet.
 
 ```python
+from advancedbilling.advanced_billing_client import AdvancedBillingClient
+from advancedbilling.http.auth.basic_auth import BasicAuthCredentials
+
 client = AdvancedBillingClient(
     basic_auth_credentials=BasicAuthCredentials(
         username='BasicAuthUserName',

--- a/doc/client.md
+++ b/doc/client.md
@@ -20,6 +20,10 @@ The following parameters are configurable for the API Client:
 The API client can be initialized as follows:
 
 ```python
+from advancedbilling.advanced_billing_client import AdvancedBillingClient
+from advancedbilling.configuration import Environment
+from advancedbilling.http.auth.basic_auth import BasicAuthCredentials
+
 client = AdvancedBillingClient(
     basic_auth_credentials=BasicAuthCredentials(
         username='BasicAuthUserName',


### PR DESCRIPTION
This pull request updates the documentation to include necessary import statements for initializing the `AdvancedBillingClient` and setting up Basic Authentication credentials. These changes aim to improve clarity and usability for developers referencing the documentation.

### Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R65): Added import statements for `AdvancedBillingClient`, `Environment`, and `BasicAuthCredentials` in the example code for initializing the API client.
* [`doc/auth/basic-authentication.md`](diffhunk://#diff-8bbf82c319e85c2062bfb073e926fce7bf6176413a73c2602cbb7d44e953488aR26-R28): Included import statements for `AdvancedBillingClient` and `BasicAuthCredentials` in the example code for setting up Basic Authentication.
* [`doc/client.md`](diffhunk://#diff-8d365b17c7a0d6745216f28bcbf704122d6d0fd7a4338cca9edb8a6c335cb137R23-R26): Updated the example code for initializing the API client to include import statements for `AdvancedBillingClient`, `Environment`, and `BasicAuthCredentials`.